### PR TITLE
Update package.json to point to proper repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cschleiden/github-actions-hero.git"
+    "url": "git+https://github.com/cschleiden/github-actions-parser.git"
   },
   "files": [
     "dist"


### PR DESCRIPTION
I was trying to find the source for this project through npm which was previously leading to the `github-actions-hero` repo which based on the commit history was a monorepo. I moved it to point now to this repo.