### PR TITLE
feat: add released type for releases

### DIFF
--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -638,7 +638,8 @@
                       "created",
                       "edited",
                       "deleted",
-                      "prereleased"
+                      "prereleased",
+                      "released"
                     ]
                   },
                   "default": [
@@ -647,7 +648,8 @@
                     "created",
                     "edited",
                     "deleted",
-                    "prereleased"
+                    "prereleased",
+                    "released"
                   ]
                 }
               }


### PR DESCRIPTION
Allows selecting "released" as an option to the enum for the release trigger.

This is listed in the [github docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release)