### PR TITLE
Rename 'macos-11.0' to 'macos-11'

### DIFF
--- a/src/lib/workflowschema/workflowSchema.ts
+++ b/src/lib/workflowschema/workflowSchema.ts
@@ -95,7 +95,7 @@ const runsOn = (context: Context): NodeDesc => ({
           "windows-latest",
           "windows-2019",
           "macos-latest",
-          "macos-11.0",
+          "macos-11",
           "macos-10.15",
           "self-hosted",
         ]);


### PR DESCRIPTION
Recently, 'macos-11.0' image spec image label was renamed to 'macos-11'. We need to reflect this changes in VS Code extension