### PR TITLE
Add missing pull_request types

### DIFF
--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -569,11 +569,14 @@
                       "closed",
                       "reopened",
                       "synchronize",
+                      "converted_to_draft",
                       "ready_for_review",
                       "locked",
                       "unlocked",
                       "review_requested",
-                      "review_request_removed"
+                      "review_request_removed",
+                      "auto_merge_enabled",
+                      "auto_merge_disabled"
                     ]
                   },
                   "default": ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
Heyo 👋 !

We got an error from https://github.com/cschleiden/actions-linter (🙇 for that package as well!):

```
Error: 'auto_merge_enabled' is not in the list of allowed values
```

I assume that's because of the missing types in this package?

Based on https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request, adding these 3 types to the schema:

* `auto_merge_enabled`
* `auto_merge_disabled`
* `converted_to_draft `

