### PR TITLE
Support workflow_dispatch Inputs Type and Options

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -22,7 +22,7 @@ export interface OnPaths {
   "paths-ignore"?: string[];
 }
 
-export type WorkflowDispatchInputsType = 'boolean' | 'number' | 'string' | 'choice';
+export type WorkflowDispatchInputsType = 'boolean' | 'string' | 'choice' | 'environment';
 
 export type On = {
   issues?: OnTypes<IssueActivities>;

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -22,6 +22,8 @@ export interface OnPaths {
   "paths-ignore"?: string[];
 }
 
+export type WorkflowDispatchInputsType = 'boolean' | 'number' | 'string' | 'choice';
+
 export type On = {
   issues?: OnTypes<IssueActivities>;
 
@@ -35,8 +37,10 @@ export type On = {
     inputs?: {
       [inputName: string]: {
         required?: boolean;
+        type?: WorkflowDispatchInputsType;
         description?: string;
         default?: string;
+        options?: string[];
       };
     };
   };

--- a/src/lib/workflowschema/schema/events.ts
+++ b/src/lib/workflowschema/schema/events.ts
@@ -315,6 +315,18 @@ export const eventMap: NodeDescMap = mergeDeep(
               description: {
                 type: "value",
               },
+              type: {
+                type: "value",
+                allowedValues: [
+                  {value: 'boolean'},
+                  {value: 'number'},
+                  {value: 'string'},
+                  {value: 'choice'},
+                ]
+              },
+              options: {
+                type: "sequence"
+              },
               default: {
                 type: "value",
               },

--- a/src/lib/workflowschema/schema/events.ts
+++ b/src/lib/workflowschema/schema/events.ts
@@ -319,9 +319,9 @@ export const eventMap: NodeDescMap = mergeDeep(
                 type: "value",
                 allowedValues: [
                   {value: 'boolean'},
-                  {value: 'number'},
                   {value: 'string'},
                   {value: 'choice'},
+                  {value: 'environment'},
                 ]
               },
               options: {

--- a/src/lib/workflowschema/workflowSchema.e2e.test.ts
+++ b/src/lib/workflowschema/workflowSchema.e2e.test.ts
@@ -190,6 +190,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
+        type: boolean
         description: 'Also create pull request if only developer dependencies changed'
         default: 'false'
   schedule:

--- a/src/lib/workflowschema/workflowSchema.hover.test.ts
+++ b/src/lib/workflowschema/workflowSchema.hover.test.ts
@@ -134,7 +134,6 @@ jobs:
   workflow_dispatch:
     inputs:
       bar:
-        type: number
         default: 42
 jobs:
   build:

--- a/src/lib/workflowschema/workflowSchema.hover.test.ts
+++ b/src/lib/workflowschema/workflowSchema.hover.test.ts
@@ -134,6 +134,7 @@ jobs:
   workflow_dispatch:
     inputs:
       bar:
+        type: number
         default: 42
 jobs:
   build:


### PR DESCRIPTION
## Reference
GitHub Actions docs on [on.workflow_dispatch.inputs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs)

## Workflow Example

```yaml
on:
  workflow_dispatch:
    inputs:
      logLevel:
        description: 'Log level'
        required: true
        default: 'warning' 
        type: choice # supported in this PR
        options: # supported in this PR
        - info
        - warning
        - debug 
      tags:
        description: 'Test scenario tags'
        required: false 
        type: boolean # supported in this PR
      environment:
        description: 'Environment to run tests against'
        type: environment # supported in this PR
        required: true 
```