### PR TITLE
feat: Add "secrets" and "uses" keys in jobs.<name>

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -146,6 +146,10 @@ export interface Job {
   container?: Container;
 
   services?: { [id: string]: Container };
+
+  uses?: string;
+
+  secrets: 'inherit' | KeyValueMap
 }
 
 export type MatrixInvocation = {

--- a/src/lib/workflowschema/workflowSchema.completion.test.ts
+++ b/src/lib/workflowschema/workflowSchema.completion.test.ts
@@ -162,10 +162,12 @@ describe("Completion", () => {
         "outputs",
         "permissions",
         "runs-on",
+        "secrets",
         "services",
         "steps",
         "strategy",
         "timeout-minutes",
+        "uses",
       ]);
     });
 
@@ -184,10 +186,12 @@ describe("Completion", () => {
           "needs",
           "outputs",
           "permissions",
+          "secrets",
           "services",
           "steps",
           "strategy",
           "timeout-minutes",
+          "uses",
         ]
       );
     });

--- a/src/lib/workflowschema/workflowSchema.e2e.test.ts
+++ b/src/lib/workflowschema/workflowSchema.e2e.test.ts
@@ -173,6 +173,28 @@ jobs:
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("no validation errors when reusing other workflow in a job", async () => {
+    const result = await parse(
+      context,
+      'workflow.yml',
+      `name: Deploy
+on:
+  push:
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+  tests2:
+    uses: ./.github/workflows/tests.yml
+    secrets:
+      NODE_ENV: \${{ secrets.NODE_ENV }}`
+    );
+
+    const diagnosticsAsText = JSON.stringify(result.diagnostics)
+    expect(diagnosticsAsText).not.toContain("Key 'uses' is not allowed")
+    expect(diagnosticsAsText).not.toContain("Key 'secrets' is not allowed")
+  })
+
   it("supports workflow_dispatch inputs", async () => {
     const result = await parse(
       context,

--- a/src/lib/workflowschema/workflowSchema.ts
+++ b/src/lib/workflowschema/workflowSchema.ts
@@ -387,6 +387,25 @@ You can provide the environment as only the environment \`name\`, or as an envir
       },
       required: ["matrix"],
     },
+    uses: value('The location and version of a reusable workflow file to run as a job. For more information, see [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).'),
+    secrets: {
+      type: "oneOf",
+      oneOf: [
+        {
+          type: "value",
+          allowedValues: [
+            { value: "inherit" }
+          ],
+        },
+        {
+          type: "map",
+          itemDesc: {
+            type: "value",
+          },
+        }
+      ],
+      description: "A map of secrets that are passed to the called workflow. You can also use the \"inherit\" keyword to pass all the calling workflow's secrets to the called workflow."
+    }
   },
 
   required: ["runs-on", "steps"],


### PR DESCRIPTION
Github allows [reuse workflow files](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretsinherit) but the vscode-github-actions extension shows errors when trying to use this feature.

![image](https://user-images.githubusercontent.com/3616259/167238056-5675fa21-f777-486f-9147-97acaa62ea68.png)

This pr fixes that.
