### PR TITLE
Extend supported contexts, add context `inputs`

### DIFF
--- a/src/lib/expressions/parser.ts
+++ b/src/lib/expressions/parser.ts
@@ -48,6 +48,7 @@ export const Contexts = [
   "strategy",
   "matrix",
   "needs",
+  "inputs",
 ].map((c) =>
   chevrotain.createToken({
     name: `Context${c}`,


### PR DESCRIPTION
Great package. We've used it for resolving variables from GithubActions contexts. 

I've tried to resolve context [`inputs`](https://docs.github.com/en/actions/learn-github-actions/contexts#inputs-context) but have not found it in the list of supported contexts. 

I added the line `inputs` in supported contexts. My experiment with locally built action works well when I resolve the context by `evaluate expression`.

Please, tell me how I can improve the PR.